### PR TITLE
Mobile version of Settings page

### DIFF
--- a/ui/src/pages/settingsPage/components/CategoryAccount.tsx
+++ b/ui/src/pages/settingsPage/components/CategoryAccount.tsx
@@ -1,5 +1,6 @@
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import { useAuth } from "@/context/auth";
 import { toast } from "sonner";
 
@@ -9,7 +10,7 @@ export function ProfileSettingsCategoryAccount() {
 
   return (
     <div className="flex flex-col gap-2 self-stretch">
-      <h4>Email</h4>
+      <Label>Email</Label>
       <Input
         disabled
         value={email ? email : "???"}
@@ -17,25 +18,25 @@ export function ProfileSettingsCategoryAccount() {
       ></Input>
       <h3>Change Password</h3>
       <hr className="h-px self-stretch bg-[#7F7F7E]"></hr>
-      <h4>Current Password</h4>
+      <Label>Current Password</Label>
       <Input
         type="password"
         placeholder="Enter current password"
         className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
       ></Input>
-      <h4>New Password</h4>
+      <Label>New Password</Label>
       <Input
         type="password"
         placeholder="Enter new password"
         className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
       ></Input>
-      <h4>Confirm New Password</h4>
+      <Label>Confirm New Password</Label>
       <Input
         type="password"
         placeholder="Enter new password again"
         className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
       ></Input>
-      <Button className="mt-2 max-w-[130px]">Save Changes</Button>
+      <Button className="w-fit self-center">Save Changes</Button>
       <h3>Account Data</h3>
       <hr className="h-px self-stretch bg-[#7F7F7E]"></hr>
       {/*

--- a/ui/src/pages/settingsPage/components/CategoryAppearance.tsx
+++ b/ui/src/pages/settingsPage/components/CategoryAppearance.tsx
@@ -6,6 +6,7 @@ import {
 } from "@/components/ui/dropdown";
 import { ChevronDown } from "lucide-react";
 import { TUserSettings } from "../settingsPage";
+import { Label } from "@/components/ui/label";
 
 export function ProfileSettingsCategoryAppearance({
   updateSetting,
@@ -16,12 +17,12 @@ export function ProfileSettingsCategoryAppearance({
 }) {
   return (
     <div className="flex flex-1 flex-col gap-2 self-stretch">
-      <div className="flex items-start gap-2 self-stretch">
-        <div className="flex flex-1 flex-col items-start justify-center gap-2 self-stretch">
-          <h4>Theme</h4>
+      <div className="flex flex-col items-start gap-2 self-stretch sm:flex-row">
+        <div className="flex flex-col items-start justify-center gap-2 self-stretch sm:flex-1">
+          <Label>Theme</Label>
           <Dropdown>
-            <DropdownTrigger>
-              <div className="flex min-h-9 min-w-[295px] items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2">
+            <DropdownTrigger className="w-full">
+              <div className="flex min-h-9 w-full items-center justify-between gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2">
                 <p className="text-base font-medium capitalize leading-normal">
                   {settings.theme || ""}
                 </p>
@@ -46,11 +47,11 @@ export function ProfileSettingsCategoryAppearance({
             </DropdownContent>
           </Dropdown>
         </div>
-        <div className="flex flex-1 flex-col items-start justify-center gap-2 self-stretch">
-          <h4>Font</h4>
+        <div className="flex flex-col items-start justify-center gap-2 self-stretch sm:flex-1">
+          <Label>Font</Label>
           <Dropdown>
-            <DropdownTrigger>
-              <div className="flex min-h-9 min-w-[295px] items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2">
+            <DropdownTrigger className="w-full">
+              <div className="flex min-h-9 w-full items-center justify-between gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2">
                 <p className="text-base font-medium capitalize leading-normal">
                   {settings.font_size || ""}
                 </p>

--- a/ui/src/pages/settingsPage/components/CategoryHelpAndSupport.tsx
+++ b/ui/src/pages/settingsPage/components/CategoryHelpAndSupport.tsx
@@ -1,14 +1,14 @@
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
-import { Trash2 } from "lucide-react";
 import { useRef } from "react";
+import { Label } from "@/components/ui/label";
 
 export function ProfileSettingsCategoryHelpAndSupport() {
   const feedback = useRef<HTMLTextAreaElement>(null);
 
   return (
     <div className="flex flex-col gap-2 self-stretch">
-      <h4>Helpful Links</h4>
+      <Label>Helpful Links</Label>
       <div className="flex items-start gap-3">
         <p className="cursor-pointer text-sm font-normal leading-normal underline decoration-solid transition-colors hover:text-purple">
           FAQ
@@ -17,19 +17,22 @@ export function ProfileSettingsCategoryHelpAndSupport() {
           Knowledge Base
         </p>
       </div>
-      <h3>Give us Feedback</h3>
-      <hr className="h-px self-stretch bg-[#7F7F7E]"></hr>
-      <Textarea ref={feedback}></Textarea>
+      <Label>Give us Feedback</Label>
+      <Textarea
+        ref={feedback}
+        className="flex min-h-[67px] items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
+        placeholder="Type your feedback here"
+        id="feedback"
+      ></Textarea>
       <Button
         onClick={() => {
           if (feedback.current) {
             feedback.current.value = "";
           }
         }}
-        className="max-w-[150px]"
-        variant={"destructive"}
+        className="self-center"
       >
-        <Trash2></Trash2> Submit
+        Submit Feedback
       </Button>
     </div>
   );

--- a/ui/src/pages/settingsPage/components/CategoryProfile.tsx
+++ b/ui/src/pages/settingsPage/components/CategoryProfile.tsx
@@ -2,7 +2,9 @@ import { Textarea } from "@/components/ui/textarea";
 import { useAuth } from "@/context/auth";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
-import { Youtube, Instagram, Music2, ImageUp, X } from "lucide-react";
+import { Label } from "@/components/ui/label";
+import { ImageUp, X } from "lucide-react";
+import { Instagram, YouTube, AudiotrackRounded } from "@mui/icons-material";
 import {
   Dialog,
   DialogClose,
@@ -66,7 +68,7 @@ export function ProfileSettingsCategoryProfile({
 
   return (
     <div className="flex flex-col gap-2 self-stretch">
-      <div className="flex items-center gap-5 self-stretch">
+      <div className="flex w-full flex-col items-center gap-5 self-stretch sm:flex-row">
         <Dialog
           onOpenChange={() => {
             setPfpSelected(false);
@@ -105,7 +107,7 @@ export function ProfileSettingsCategoryProfile({
                   onChange={handleFileChange}
                   ref={pfp_upload_input}
                   type="file"
-                  name="pfp"
+                  id="pfp"
                   accept="image/jpeg, image/bmp, image/png, image/tiff, image/gif"
                 />
                 {pfpSelected && <Button onClick={handleSetPfp}>Upload</Button>}
@@ -116,9 +118,9 @@ export function ProfileSettingsCategoryProfile({
             </DialogContent>
           </DialogPortal>
         </Dialog>
-        <div className="flex flex-1 flex-col items-start gap-3">
+        <div className="flex w-full flex-1 flex-col items-start gap-3">
           <div className="flex flex-col items-start justify-center gap-2 self-stretch">
-            <h4>Display Name</h4>
+            <Label htmlFor="display_name">Display Name</Label>
             <Input
               maxLength={64}
               onChange={(event) => {
@@ -127,60 +129,67 @@ export function ProfileSettingsCategoryProfile({
               defaultValue={settings.displayName || ""}
               placeholder={user?.username}
               className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
+              id="display_name"
             />
           </div>
 
           <div className="flex flex-col items-start justify-center gap-2 self-stretch">
-            <h4 className="text-[#7F7F7E]">Username</h4>
+            <Label className="text-[#7F7F7E]" htmlFor="username">
+              Username
+            </Label>
             <Input
               disabled
               value={"@" + user?.username}
               className="flex items-start gap-3 self-stretch rounded-xl border border-[#7F7F7E] bg-black px-4 py-2 text-[#7F7F7E]"
+              id="username"
             />
           </div>
 
           <div className="flex flex-col items-start justify-center gap-2 self-stretch">
-            <h4>Status</h4>
+            <Label htmlFor="status">Status</Label>
             <Input
               maxLength={128}
               onChange={(event) => {
                 updateSetting("status", event.target.value);
               }}
               defaultValue={settings.status || ""}
-              placeholder="..."
+              placeholder="What's on your mind?"
               className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
+              id="status"
             />
           </div>
         </div>
       </div>
       <div className="flex flex-col items-start justify-center gap-2 self-stretch">
-        <h4>Bio</h4>
+        <Label htmlFor="bio">Bio</Label>
         <Textarea
           maxLength={30000}
           onChange={(event) => {
             updateSetting("bio", event.target.value);
           }}
           defaultValue={settings.bio || ""}
-          placeholder="write about yourself..."
+          placeholder="Tell us a little about yourself..."
           className="flex min-h-[67px] items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
+          id="bio"
         ></Textarea>
       </div>
-      <div className="flex items-start justify-center gap-2 self-stretch">
-        <div className="flex flex-1 flex-col items-start justify-center gap-2 self-stretch">
-          <h4>Pronouns</h4>
+      <div className="flex flex-col items-start justify-center gap-3 self-stretch sm:flex-row">
+        <div className="flex flex-col items-start justify-center gap-2 self-stretch sm:flex-1">
+          <Label htmlFor="pronouns">Pronouns</Label>
           <Input
             maxLength={32}
             onChange={(event) => {
               updateSetting("pronouns", event.target.value);
             }}
             defaultValue={settings.pronouns || ""}
-            placeholder="it/that"
+            placeholder="e.g. She/Her, He/Him, They/Them"
             className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
+            id="pronouns"
           ></Input>
         </div>
 
-        <div className="flex flex-1 flex-col items-start justify-center gap-2 self-stretch">
-          <h4>Location</h4>
+        <div className="flex flex-col items-start justify-center gap-2 self-stretch sm:flex-1">
+          <Label htmlFor="location">Location</Label>
           <Input
             maxLength={32}
             onChange={(event) => {
@@ -189,6 +198,7 @@ export function ProfileSettingsCategoryProfile({
             defaultValue={settings.location || ""}
             placeholder="Earth"
             className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
+            id="location"
           ></Input>
         </div>
       </div>
@@ -217,48 +227,57 @@ export function ProfileSettingsCategoryProfile({
       <h3>Socials</h3>
       <hr className="h-px self-stretch bg-[#7F7F7E]" />
       <div className="flex items-start gap-3 self-stretch py-3">
-        <div className="flex flex-col gap-[26px] self-stretch py-[5px]">
-          <div className="flex items-center gap-3">
-            <Instagram />
-            <h4>Instagram</h4>
+        <div className="flex w-full flex-col gap-[26px] self-stretch py-[5px]">
+          <div className="flex w-full flex-col gap-5">
+            <div className="flex w-full flex-col gap-2 sm:flex-row">
+              <div className="flex items-center gap-3 sm:w-1/4">
+                <Instagram />
+                <Label htmlFor="social_instagram">Instagram</Label>
+              </div>
+              <Input
+                maxLength={255}
+                onChange={(event) => {
+                  updateSetting("social_instagram", event.target.value);
+                }}
+                defaultValue={settings.social_instagram || ""}
+                placeholder="https://www.instagram.com/username/"
+                className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
+                id="social_instagram"
+              />
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <div className="flex items-center gap-3 sm:w-1/4">
+                <YouTube />
+                <Label htmlFor="social_youtube">Youtube</Label>
+              </div>
+              <Input
+                maxLength={255}
+                onChange={(event) => {
+                  updateSetting("social_youtube", event.target.value);
+                }}
+                defaultValue={settings.social_youtube || ""}
+                placeholder="https://www.youtube.com/username/"
+                className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
+                id="social_youtube"
+              />
+            </div>
+            <div className="flex flex-col gap-2 sm:flex-row">
+              <div className="flex items-center gap-3 sm:w-1/4">
+                <AudiotrackRounded />
+                <Label htmlFor="social_tiktok">Tiktok</Label>
+              </div>
+              <Input
+                maxLength={255}
+                onChange={(event) => {
+                  updateSetting("social_tiktok", event.target.value);
+                }}
+                defaultValue={settings.social_tiktok || ""}
+                placeholder="https://www.tiktok.com/@username/"
+                className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
+                id="social_tiktok"
+              />
+            </div>
           </div>
-          <div className="flex items-center gap-3">
-            <Youtube />
-            <h4>Youtube</h4>
-          </div>
-          <div className="flex items-center gap-3">
-            <Music2 />
-            <h4>Tiktok</h4>
-          </div>
-        </div>
-        <div className="flex flex-1 flex-col gap-5">
-          <Input
-            maxLength={255}
-            onChange={(event) => {
-              updateSetting("social_instagram", event.target.value);
-            }}
-            defaultValue={settings.social_instagram || ""}
-            placeholder="https://www.instagram.com/username/"
-            className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
-          ></Input>
-          <Input
-            maxLength={255}
-            onChange={(event) => {
-              updateSetting("social_youtube", event.target.value);
-            }}
-            defaultValue={settings.social_youtube || ""}
-            placeholder="https://www.youtube.com/username/"
-            className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
-          ></Input>
-          <Input
-            maxLength={255}
-            onChange={(event) => {
-              updateSetting("social_tiktok", event.target.value);
-            }}
-            defaultValue={settings.social_tiktok || ""}
-            placeholder="https://www.tiktok.com/@username/"
-            className="flex items-start gap-3 self-stretch rounded-xl border border-white bg-black px-4 py-2"
-          ></Input>
         </div>
       </div>
     </div>


### PR DESCRIPTION
This pull request includes a series of changes to the `ui/src/pages/settingsPage/components` directory to improve the consistency and accessibility of the settings pages by replacing `<h4>` elements with `<Label>` components and updating the layout for better responsiveness.

### Consistency and Accessibility Improvements:

* [`ui/src/pages/settingsPage/components/CategoryAccount.tsx`](diffhunk://#diff-3eaf636ef5123e5d2694975f37403e0a3efce9ac52a3609c9850a9383f9ca3e8R3): Replaced `<h4>` elements with `<Label>` components for email, current password, new password, and confirm new password fields. Adjusted the "Save Changes" button to be centered. [[1]](diffhunk://#diff-3eaf636ef5123e5d2694975f37403e0a3efce9ac52a3609c9850a9383f9ca3e8R3) [[2]](diffhunk://#diff-3eaf636ef5123e5d2694975f37403e0a3efce9ac52a3609c9850a9383f9ca3e8L12-R39)
* [`ui/src/pages/settingsPage/components/CategoryAppearance.tsx`](diffhunk://#diff-8a08901bbdc260a7741d0476afd6532f7eb01132e19b0f30ef454c37c081991aR9): Replaced `<h4>` elements with `<Label>` components for theme and font fields. Updated layout to use flexbox for better responsiveness. [[1]](diffhunk://#diff-8a08901bbdc260a7741d0476afd6532f7eb01132e19b0f30ef454c37c081991aR9) [[2]](diffhunk://#diff-8a08901bbdc260a7741d0476afd6532f7eb01132e19b0f30ef454c37c081991aL19-R25) [[3]](diffhunk://#diff-8a08901bbdc260a7741d0476afd6532f7eb01132e19b0f30ef454c37c081991aL49-R54)
* [`ui/src/pages/settingsPage/components/CategoryHelpAndSupport.tsx`](diffhunk://#diff-ff21d73a3ce3b7d3723b88bdafd3206212fd884c3f01f5b11f00a495f78e9729L3-R11): Replaced `<h4>` elements with `<Label>` components for helpful links and feedback fields. Updated the feedback textarea and button for better styling and accessibility. [[1]](diffhunk://#diff-ff21d73a3ce3b7d3723b88bdafd3206212fd884c3f01f5b11f00a495f78e9729L3-R11) [[2]](diffhunk://#diff-ff21d73a3ce3b7d3723b88bdafd3206212fd884c3f01f5b11f00a495f78e9729L20-R35)
* [`ui/src/pages/settingsPage/components/CategoryProfile.tsx`](diffhunk://#diff-c4c97881b278efaf4c84a512ec1112ff80d2661d0e2081cf1a931338aed66909L5-R7): Replaced `<h4>` elements with `<Label>` components for display name, username, status, bio, pronouns, location, and social media fields. Added `id` attributes to inputs for accessibility and updated layout for better responsiveness. [[1]](diffhunk://#diff-c4c97881b278efaf4c84a512ec1112ff80d2661d0e2081cf1a931338aed66909L5-R7) [[2]](diffhunk://#diff-c4c97881b278efaf4c84a512ec1112ff80d2661d0e2081cf1a931338aed66909L69-R71) [[3]](diffhunk://#diff-c4c97881b278efaf4c84a512ec1112ff80d2661d0e2081cf1a931338aed66909L108-R110) [[4]](diffhunk://#diff-c4c97881b278efaf4c84a512ec1112ff80d2661d0e2081cf1a931338aed66909L119-R123) [[5]](diffhunk://#diff-c4c97881b278efaf4c84a512ec1112ff80d2661d0e2081cf1a931338aed66909R132-R192) [[6]](diffhunk://#diff-c4c97881b278efaf4c84a512ec1112ff80d2661d0e2081cf1a931338aed66909R201) [[7]](diffhunk://#diff-c4c97881b278efaf4c84a512ec1112ff80d2661d0e2081cf1a931338aed66909L220-L234) [[8]](diffhunk://#diff-c4c97881b278efaf4c84a512ec1112ff80d2661d0e2081cf1a931338aed66909L243-R252) [[9]](diffhunk://#diff-c4c97881b278efaf4c84a512ec1112ff80d2661d0e2081cf1a931338aed66909L252-R268) [[10]](diffhunk://#diff-c4c97881b278efaf4c84a512ec1112ff80d2661d0e2081cf1a931338aed66909L261-R280)